### PR TITLE
remove the max email cap and instead scan all emails

### DIFF
--- a/gmail_client.py
+++ b/gmail_client.py
@@ -42,7 +42,7 @@ class GmailAnalyzer:
         """Split an array into chunks of a specified size."""
         return [array[i : i + chunk_size] for i in range(0, len(array), chunk_size)]
 
-    def get_sender_statistics(self, max_emails, progress_callback=None) -> pd.DataFrame:
+    def get_sender_statistics(self, progress_callback=None) -> pd.DataFrame:
         """Analyze recent emails and return a DataFrame with sender information"""
         mail = self.connect()
 
@@ -50,9 +50,6 @@ class GmailAnalyzer:
         _, messages = mail.uid("search", None, "ALL")
 
         message_ids = messages[0].split()
-        message_ids = (
-            message_ids[-max_emails:] if len(message_ids) > max_emails else message_ids
-        )
 
         sender_data = {}
         total_messages = len(message_ids)

--- a/main.py
+++ b/main.py
@@ -33,14 +33,6 @@ def main():
         st.session_state.app_password = st.text_input(
             "Gmail App Password", value=st.session_state.app_password, type="password"
         )
-        max_emails = st.number_input(
-            "Maximum emails to analyze",
-            min_value=10,
-            max_value=1000,
-            value=1000,
-            step=10,
-        )
-
         if st.button("Connect"):
             if st.session_state.email_address and st.session_state.app_password:
                 analyzer = GmailAnalyzer(
@@ -68,7 +60,7 @@ def main():
                     status_text.text(f"Processing email {current}/{total}")
 
                 st.session_state.email_data = analyzer.get_sender_statistics(
-                    max_emails, progress_callback=update_progress
+                    progress_callback=update_progress
                 )
 
                 progress_bar.empty()
@@ -90,7 +82,7 @@ def main():
 
                     with col2:
                         if st.button(
-                            "Delete all email(s) from this sender",
+                            f"Delete {row["Count"]} email(s) from this sender",
                             key=f"delete_{index}",
                         ):
                             deleted_emails_count = analyzer.delete_emails_from_sender(


### PR DESCRIPTION
Anyways now that we are processing emails in batches of 100, speed should not be a massive constraint. 

If someone has 20000 emails, it'll take a couple of minutes but all operations will be accurate and numbers will also look good while deleting. 