### PR TITLE
Feature/folder selector

### DIFF
--- a/mail_client.py
+++ b/mail_client.py
@@ -7,6 +7,24 @@ from typing import Optional, List, Any
 
 import pandas as pd
 
+# Folder options per provider. Keys are display labels shown in the UI,
+# values are the IMAP folder names sent to the server.
+# Yahoo's "Archive" is a user-facing archive folder (explicitly archived emails only).
+# Gmail's "All Mail" contains everything: inbox, archived, sent, etc.
+SCAN_FOLDERS = {
+    "gmail.com": {
+        "Inbox": "INBOX",
+        "All Mail": "[Gmail]/All Mail",
+    },
+    "yahoo.com": {
+        "Inbox": "INBOX",
+        "Archive": "Archive",
+    },
+}
+
+# Fallback for unsupported providers — inbox only
+DEFAULT_FOLDERS = {"Inbox": "INBOX"}
+
 
 class MailAnalyzer:
     def __init__(self, email_address, app_password):
@@ -56,6 +74,13 @@ class MailAnalyzer:
             return endpoints[domain]
         else:
             raise ValueError(f"Unsupported email domain: {domain}")
+        
+    @staticmethod
+    def __imap_folder_name(folder: str) -> str:
+        """Wrap folder name in quotes if it contains spaces or special chars."""
+        if " " in folder or "/" in folder:
+            return f'"{folder}"'
+        return folder
 
     def connect(self) -> imaplib.IMAP4_SSL:
         """Create a fresh IMAP connection"""
@@ -68,11 +93,16 @@ class MailAnalyzer:
         """Split an array into chunks of a specified size."""
         return [array[i : i + chunk_size] for i in range(0, len(array), chunk_size)]
 
-    def get_sender_statistics(self, progress_callback=None) -> pd.DataFrame:
-        """Analyze recent emails and return a DataFrame with sender information"""
+    def get_sender_statistics(
+        self, progress_callback=None, folder: str = "INBOX"
+    ) -> pd.DataFrame:
+        """Analyze emails in the given folder and return a DataFrame with sender information"""
         mail = self.connect()
 
-        mail.select("INBOX")
+        result, _ = mail.select(self.__imap_folder_name(folder))
+        if result != "OK":
+            raise Exception(f"Could not select folder: {folder}")
+
         _, messages = mail.uid("search", None, "ALL")
 
         message_ids = messages[0].split()
@@ -87,8 +117,10 @@ class MailAnalyzer:
                 processed_messages += len(batch_ids)
                 progress_callback(processed_messages, total_messages)
 
+            # BODY.PEEK[] fetches full message content without marking emails as
+            # read — RFC822 would implicitly set the \Seen flag on every message.
             _, msg_data = mail.uid(
-                "fetch", ",".join([el.decode() for el in batch_ids]), "(RFC822)"
+                "fetch", ",".join([el.decode() for el in batch_ids]), "(BODY.PEEK[])"
             )
 
             for response_part in msg_data:
@@ -155,10 +187,13 @@ class MailAnalyzer:
         except Exception as e:
             return None
 
-    def delete_emails_from_sender(self, sender_email) -> int:
+    def delete_emails_from_sender(self, sender_email, folder: str = "INBOX") -> int:
         mail = self.connect()
 
-        mail.select("INBOX", readonly=False)
+        result, _ = mail.select(self.__imap_folder_name(folder), readonly=False)
+        if result != "OK":
+            raise Exception(f"Could not select folder: {folder}")
+
         _, messages = mail.uid("SEARCH", None, f'FROM "{sender_email}"')
         if not messages[0]:
             mail.logout()

--- a/mail_client.py
+++ b/mail_client.py
@@ -117,10 +117,11 @@ class MailAnalyzer:
                 processed_messages += len(batch_ids)
                 progress_callback(processed_messages, total_messages)
 
-            # BODY.PEEK[] fetches full message content without marking emails as
+            # BODY.PEEK[] fetches message content without marking emails as
             # read — RFC822 would implicitly set the \Seen flag on every message.
+            # Although, to speed upscanning I am only looking at headers.
             _, msg_data = mail.uid(
-                "fetch", ",".join([el.decode() for el in batch_ids]), "(BODY.PEEK[])"
+                "fetch", ",".join([el.decode() for el in batch_ids]), "(BODY.PEEK[HEADER.FIELDS (FROM LIST-UNSUBSCRIBE)])"
             )
 
             for response_part in msg_data:

--- a/main.py
+++ b/main.py
@@ -17,6 +17,14 @@ def get_selected_imap_folder() -> str:
 
 
 def analyze_emails_component(analyzer):
+    folder_options = list(get_folder_options().keys())
+    st.session_state.scan_folder = st.selectbox(       # st. not st.sidebar.
+        "Folder to scan",
+        options=folder_options,
+        index=folder_options.index(st.session_state.scan_folder)
+        if st.session_state.scan_folder in folder_options
+        else 0,
+    )
     if st.button("Analyze Emails"):
         progress_bar = st.progress(0)
         status_text = st.empty()
@@ -163,16 +171,6 @@ def sidebar_component():
                         st.session_state.email_data = None
                         st.success("Successfully connected!")
                         st.rerun()
-
-        st.sidebar.header("Scan Options")
-        folder_options = list(get_folder_options().keys())
-        st.session_state.scan_folder = st.sidebar.selectbox(
-            "Folder to scan",
-            options=folder_options,
-            index=folder_options.index(st.session_state.scan_folder)
-            if st.session_state.scan_folder in folder_options
-            else 0,
-        )
 
         # Add a button to star the repository
         st.sidebar.markdown(

--- a/main.py
+++ b/main.py
@@ -1,7 +1,19 @@
 import math
 
 import streamlit as st
-from mail_client import MailAnalyzer
+from mail_client import MailAnalyzer, SCAN_FOLDERS, DEFAULT_FOLDERS
+
+
+def get_folder_options() -> dict:
+    """Return the folder options dict for the current user's email provider."""
+    domain = st.session_state.get("domain")
+    return SCAN_FOLDERS.get(domain, DEFAULT_FOLDERS)
+
+
+def get_selected_imap_folder() -> str:
+    """Resolve the selected display label to its IMAP folder name."""
+    folder_options = get_folder_options()
+    return folder_options.get(st.session_state.scan_folder, "INBOX")
 
 
 def analyze_emails_component(analyzer):
@@ -28,7 +40,8 @@ def analyze_emails_component(analyzer):
             )
 
         st.session_state.email_data = analyzer.get_sender_statistics(
-            progress_callback=update_progress
+            progress_callback=update_progress,
+            folder=get_selected_imap_folder(),
         )
 
         progress_bar.empty()
@@ -93,9 +106,16 @@ def sender_list_for_cleanup_component():
                 )
                 # TODO: move to bulk delete
                 for sender in sender_ids_to_be_cleaned:
-                    deleted_count = analyzer.delete_emails_from_sender(sender)
+                    deleted_count = analyzer.delete_emails_from_sender(
+                        sender, folder=get_selected_imap_folder()
+                    )
                     st.toast(f"Moved {deleted_count} emails from {sender} to the bin!")
-                st.session_state.email_data = None
+
+                # Remove deleted senders from the dataframe instead of clearing.
+                # Avoids forcing a full re-scan after every delete.
+                st.session_state.email_data = st.session_state.email_data[
+                    ~st.session_state.email_data["Email"].isin(sender_ids_to_be_cleaned)
+                ].reset_index(drop=True)
                 st.rerun()
 
 
@@ -135,9 +155,24 @@ def sidebar_component():
                     test_conn = analyzer.connect()
                     if test_conn:
                         test_conn.logout()
-                        st.success("Successfully connected to Gmail!")
+                        # Store domain so folder options can be scoped per provider
+                        st.session_state.domain = (
+                            st.session_state.email_address.lower().split("@")[-1]
+                        )
+                        st.session_state.scan_folder = "Inbox"
                         st.session_state.email_data = None
+                        st.success("Successfully connected!")
                         st.rerun()
+
+        st.sidebar.header("Scan Options")
+        folder_options = list(get_folder_options().keys())
+        st.session_state.scan_folder = st.sidebar.selectbox(
+            "Folder to scan",
+            options=folder_options,
+            index=folder_options.index(st.session_state.scan_folder)
+            if st.session_state.scan_folder in folder_options
+            else 0,
+        )
 
         # Add a button to star the repository
         st.sidebar.markdown(
@@ -160,6 +195,10 @@ def main():
         st.session_state.app_password = None
     if "email_data" not in st.session_state:
         st.session_state.email_data = None
+    if "domain" not in st.session_state:
+        st.session_state.domain = None
+    if "scan_folder" not in st.session_state:
+        st.session_state.scan_folder = "Inbox"
 
     # Sidebar for authentication
     sidebar_component()
@@ -182,7 +221,7 @@ def main():
         ### Instructions:
         1. Enter your Gmail or Yahoo address
         2. Enter your [Gmail App Password](https://myaccount.google.com/apppasswords) or [Yahoo App Password](https://help.yahoo.com/kb/SLN15241.html)
-        3. Select the number of recent emails to analyze
+        3. Select the folder to scan from the sidebar
         4. Click Connect to start analyzing your inbox
         
         **Note:** _This app requires a App Password, not your regular password_!


### PR DESCRIPTION
## Changes

**Provider-aware folder selector**
Added a dropdown above the Analyze button to pick which folder to scan.
Options are scoped to your email provider after login 

- Gmail gets Inbox and All Mail 
- Yahoo gets Inbox and Archive
- All else falls back to Inbox 

Also fixes the IMAP quoting issue for folder names with spaces or 
slashes.

**Emails no longer marked as read after scanning**
The fetch was using RFC822 which basically sets \Seen on every message.
Which then made every email get marked as read. It's now switched 
to BODY.PEEK[] to fix that.

**Faster scans**
Scanning was fetching full message bodies when it only actually needs two 
headers. Switched to header-only fetching. My 11000 email inbox  oringally took
~30 minutes, to basically an instant.


**No more re-scan after deleting**
After deleting senders the app was wiping session state and kicking you back 
to re-scan from scratch. Now it just removes the deleted rows from the 
existing table in place. Addresses the blank screen reported in #10.


Tested with my Gmail account. 